### PR TITLE
Fixed project level CMIS setting update

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ RedmineApp::Application.routes.draw do
   match 'sync_cmis_spaces', :controller => 'cmis', :via => [:get, :post]
   match 'projects/:project_id/cmis/:action', :controller => 'cmis', :via => [:get, :post]
   match 'projects/:project_id/:id/cmis/:action', :controller => 'cmis', :via => [:get, :post]
-  match 'projects/:id/cmis_project_setting/:action', :controller => 'cmis_project_setting', :via => [:get, :post, :put]
+  match 'projects/:id/cmis_project_setting/:action', :controller => 'cmis_project_setting', :via => [:get, :post, :put, :patch]
 end

--- a/init.rb
+++ b/init.rb
@@ -35,8 +35,8 @@ Redmine::Plugin.register :redmine_cmis do
 	menu :project_menu, :cmis, { :controller => 'cmis', :action => 'index' }, :caption => :cmis, :after => :documents, :param => :project_id
 
 	settings :default => {
-    'server_url' => 'http://localhost:8080/alfresco/service/cmis',
-    'repository_id' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    'server_url' => 'http://alfresco.example.com:8080/alfresco/api/-default-/public/cmis/versions/1.0/atom',
+    'repository_id' => '-default-',
 		'server_login' => 'user',
 		'server_password' => 'password',
 		'documents_path_base' => 'REDMINE',


### PR DESCRIPTION
Added PATH method to routes.rb

Working Alfresco 5.x URL 
http://alfresco.example.com:8080/alfresco/api/-default-/public/cmis/versions/1.0/atom